### PR TITLE
add __rt_rvstack

### DIFF
--- a/components/esp_system/ld/esp32c3/sections.ld.in
+++ b/components/esp_system/ld/esp32c3/sections.ld.in
@@ -188,6 +188,7 @@ SECTIONS
       __stack_cpu0 = .;
       __stack_end__ = .;
   } > dram0_0_seg
+  PROVIDE( __rt_rvstack = __stack_end__);
 
   .heap :
   {


### PR DESCRIPTION
add __rt_rvstack to fix esp32_c3 compile error