### PR TITLE
[HUST CSE][components] Fix null pointer problems caused by the functi…

### DIFF
--- a/components/bt/host/bluedroid/stack/btm/btm_sec.c
+++ b/components/bt/host/bluedroid/stack/btm/btm_sec.c
@@ -3952,7 +3952,9 @@ void btm_sec_auth_complete (UINT16 handle, UINT8 status)
             }
         }
     }
-
+	if (!p_dev_rec) {
+        return;
+    }
     p_dev_rec->sec_state = BTM_SEC_STATE_IDLE;
 
 #if (CLASSIC_BT_INCLUDED == TRUE)


### PR DESCRIPTION
…on btm_sec_auth_complete()
#### 为什么提交这份PR (why to submit this PR)

在btm_sec.c文件中，检查btm_sec_auth_complete函数中的指针变量p_dev_rec存在可能的空指针引用,进而引起程序异常退出。

在此给出文件的详细路径如下：

RT-Thread\esp-idf\master\components\bt\host\bluedroid\stack\btm\btm_sec.c

该空指针隐患容易导致代码崩溃，主要导致该问题的原因在于如下代码：

```c++
if (btm_cb.api.p_auth_complete_callback) {
        /* report the authentication status */
        if (old_state != BTM_PAIR_STATE_IDLE) {
            res = (*btm_cb.api.p_auth_complete_callback) (p_dev_rec->bd_addr,
                                                          p_dev_rec->dev_class,
                                                          p_dev_rec->sec_bd_name, status);
            if (res == BTM_SEC_DEV_REC_REMOVED) {
                p_dev_rec = NULL;
            }
        }
    }

    p_dev_rec->sec_state = BTM_SEC_STATE_IDLE;
```

即在之前的嵌套判断代码中将p_dev_rec 的值赋为NULL，而在嵌套判断结束后，又引用了该指针的内容，导致代码崩溃。

综上所述，笔者认为存在空指针引用的问题，提出了疑问并尝试解决该问题。

#### 你的解决方案是什么 (what is your solution)

通过理解函数想表达的含义，当指针为空时，应当退出该函数。
故在可能存在空指针引用的代码段之前，添加判断代码，在p_dev_rec为空指针时退出该函数。
此处修改参考自https://github.com/espressif/esp-idf/blob/f404fe96b17692e3f1de536a3d73a180cdb53b42/components/bt/host/bluedroid/stack/btm/btm_sec.c#L3965-L3967
修改之前的代码：

```c++
p_dev_rec->sec_state = BTM_SEC_STATE_IDLE;
```

修改之后的代码:

```c++
    if (!p_dev_rec) {
        return;
    }
    p_dev_rec->sec_state = BTM_SEC_STATE_IDLE;
```

在什么测试环境下测试通过 (what is the test environment)
all

]