### PR TITLE
[HUST CSE] Fix: ep_ type_ Str may be a null pointer

### DIFF
--- a/components/usb/usb_helpers.c
+++ b/components/usb/usb_helpers.c
@@ -200,7 +200,12 @@ static void print_ep_desc(const usb_ep_desc_t *ep_desc)
     printf("\t\tbEndpointAddress 0x%x\tEP %d %s\n", ep_desc->bEndpointAddress,
            USB_EP_DESC_GET_EP_NUM(ep_desc),
            USB_EP_DESC_GET_EP_DIR(ep_desc) ? "IN" : "OUT");
-    printf("\t\tbmAttributes 0x%x\t%s\n", ep_desc->bmAttributes, ep_type_str);
+    if(ep_type_str!=NULL){
+        printf("\t\tbmAttributes 0x%x\t%s\n", ep_desc->bmAttributes, ep_type_str);
+    }
+    else{
+        printf("\t\tError:bmAttributes type mismatch CTRL/ISOC/BULK/INT, please check!\n");
+    }
     printf("\t\twMaxPacketSize %d\n", ep_desc->wMaxPacketSize);
     printf("\t\tbInterval %d\n", ep_desc->bInterval);
 }


### PR DESCRIPTION
## 拉取/合并请求描述：(PR description)

[

#### 为什么提交这份PR (why to submit this PR)
在components/usb/usb_helpers.c这个文件中，第174行print_ep_des()函数中的ep_ type_ Str指针在case条件不满足情况下默认为空指针，在203行printf语句中会发生空指针错误，因此提交这份PR。

#### 你的解决方案是什么 (what is your solution)
添加判断语句判断该指针是否为空，若为空指针则打印类型不匹配错误信息，若不为空指针则正常执行原操作。

#### 在什么测试环境下测试通过 (what is the test environment)
只添加了判断语句和打印语句，测试一定会通过。
]

### 当前拉取/合并请求的状态 Intent for your PR

必须选择一项 Choose one (Mandatory):

- [x] 本拉取/合并请求是一个草稿版本 This PR is for a code-review and is intended to get feedback
- [ ] 本拉取/合并请求是一个成熟版本 This PR is mature, and ready to be integrated into the repo

### 代码质量 Code Quality：

我在这个拉取/合并请求中已经考虑了 As part of this pull request, I've considered the following:

- [x] 已经仔细查看过代码改动的对比 Already check the difference between PR and old code
- [x] 代码风格正确，包括缩进空格，命名及其他风格 Style guide is adhered to, including spacing, naming and other styles
- [x] 没有垃圾代码，代码尽量精简，不包含`#if 0`代码，不包含已经被注释了的代码 All redundant code is removed and cleaned up
- [x] 所有变更均有原因及合理的，并且不会影响到其他软件组件代码或BSP All modifications are justified and not affect other components or BSP
- [x] 对难懂代码均提供对应的注释 I've commented appropriately where code is tricky
- [x] 代码是高质量的 Code in this PR is of high quality
- [x] 已经使用[formatting](https://github.com/mysterywolf/formatting)等源码格式化工具确保格式符合[RT-Thread代码规范](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_cn.md) This PR complies with [RT-Thread code specification](https://github.com/RT-Thread/rt-thread/blob/master/documentation/contribution_guide/coding_style_en.md)
