### PR TITLE
[HUST CSE]Modifies the argument of the sizeof statement to a legitimate array name

### DIFF
--- a/components/app_trace/sys_view/ext/logging.c
+++ b/components/app_trace/sys_view/ext/logging.c
@@ -18,7 +18,7 @@ int esp_sysview_vprintf(const char * format, va_list args)
     portENTER_CRITICAL(&s_log_mutex);
     size_t len = vsnprintf(log_buffer, sizeof(log_buffer), format, args);
     if (len > sizeof(log_buffer) - 1) {
-        log_buffer[sizeof(log_buffer - 1)] = 0;
+        log_buffer[sizeof(log_buffer) - 1] = 0;
     }
     SEGGER_SYSVIEW_Print(log_buffer);
     portEXIT_CRITICAL(&s_log_mutex);


### PR DESCRIPTION
**问题描述**
在函数`esp_sysview_vprintf`中，21行处因后括号位置错误导致的`sizeof`语句参数异常，可能导致数组访问错误
**问题修改**
修改后括号位置，使括号仅包含合法的数组名，则sizeof语句参数正常，如下：
`log_buffer[sizeof(log_buffer - 1)] = 0;` 更改为 `log_buffer[sizeof(log_buffer) - 1] = 0;`