### PR TITLE
[HUST CSE]修改printf类型不匹配的问题

### DIFF
--- a/components/esp_hw_support/test/test_dport.c
+++ b/components/esp_hw_support/test/test_dport.c
@@ -99,7 +99,7 @@ void run_tasks(const char *task1_description, void (* task1_func)(void *), const
     if(task2_func != NULL) xTaskCreate(task2_func, task2_description, 2048, &exit_sema[1], UNITY_FREERTOS_PRIORITY - 1, &th[1]);
 #endif
 
-    printf("start wait for %d seconds [Test %s and %s]\n", delay_ms/1000, task1_description, task2_description);
+    printf("start wait for %u seconds [Test %s and %s]\n", delay_ms/1000, task1_description, task2_description);
     vTaskDelay(delay_ms / portTICK_PERIOD_MS);
 
     // set exit flag to let thread exit


### PR DESCRIPTION
### 为什么提交这份PR (why to submit this PR)
在printf输出语句中uint32_t类型的变量delay_ms对应的说明符为%d，两者并不匹配。
此处给出文件路径：/components/esp_hw_support/test/test_dport.c

查看源码：
 printf("start wait for %d seconds [Test %s and %s]\n", delay_ms/1000, task1_description, task2_description);

### 你的解决方案是什么 (what is your solution)
将%d改成%u，与uint32_t类型的变量匹配。修改后代码如下：
 printf("start wait for %u seconds [Test %s and %s]\n", delay_ms/1000, task1_description, task2_description);